### PR TITLE
[CI] Speed up builds by caching Qt install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,16 @@ jobs:
       matrix:
         variant:
           # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,     config: Release,        py-version: '3.8' }
-          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,     config: Release,        py-version: '3.9' }
-          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,     config: Release,        py-version: '3.10' }
-          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,     config: Release,        py-version: '3.11' }
-          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,     config: Release,        py-version: '3.12' }
-          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,       config: RelWithDebInfo, py-version: '3.8' }
-          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,       config: RelWithDebInfo, py-version: '3.9' }
-          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,       config: RelWithDebInfo, py-version: '3.10' }
-          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,       config: RelWithDebInfo, py-version: '3.11' }
-          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,       config: RelWithDebInfo, py-version: '3.12' }
+          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,           config: Release,        py-version: '3.8' }
+          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,           config: Release,        py-version: '3.9' }
+          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,           config: Release,        py-version: '3.10' }
+          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,           config: Release,        py-version: '3.11' }
+          - {runner: macos-13,       arch: x64, py-arch: x64, qt-compiler: clang_64,           config: Release,        py-version: '3.12' }
+          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,             config: RelWithDebInfo, py-version: '3.8' }
+          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,             config: RelWithDebInfo, py-version: '3.9' }
+          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,             config: RelWithDebInfo, py-version: '3.10' }
+          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,             config: RelWithDebInfo, py-version: '3.11' }
+          - {runner: ubuntu-22.04,   arch: x64, py-arch: x64, qt-compiler: gcc_64,             config: RelWithDebInfo, py-version: '3.12' }
           - {runner: windows-2019,   arch: x64, py-arch: x64, qt-compiler: win64_msvc2019_64,  config: RelWithDebInfo, py-version: '3.8' }
           - {runner: windows-2019,   arch: x64, py-arch: x64, qt-compiler: win64_msvc2019_64,  config: RelWithDebInfo, py-version: '3.9' }
           - {runner: windows-2019,   arch: x64, py-arch: x64, qt-compiler: win64_msvc2019_64,  config: RelWithDebInfo, py-version: '3.10' }
@@ -50,8 +50,6 @@ jobs:
       run: |
         Import-Module .\.github\Invoke-VisualStudio.ps1
         Invoke-VisualStudio2019${{ matrix.variant.arch }}
-        python -m pip install aqtinstall --user --upgrade
-        python -m aqt install-qt -O build windows desktop ${{ env.QT_VERSION }} ${{ matrix.variant.qt-compiler }}
 
     - name: Environment Setup (Linux)
       if: startsWith(matrix.variant.runner, 'ubuntu-')
@@ -60,14 +58,35 @@ jobs:
         sudo apt install -y g++ ninja-build clang
         echo CC=clang >> $GITHUB_ENV
         echo CXX=clang++ >> $GITHUB_ENV
-        python -m pip install aqtinstall --user --upgrade
-        python -m aqt install-qt -O build linux desktop ${{ env.QT_VERSION }} ${{ matrix.variant.qt-compiler }}
 
     - name: Environment Setup (MacOS)
       if: startsWith(matrix.variant.runner, 'macos-')
       run: |
         echo CC=clang >> $GITHUB_ENV
         echo CXX=clang++ >> $GITHUB_ENV
+
+    - name: Cache Artifacts
+      id: cache-artifacts
+      uses: actions/cache@v4
+      with:
+        path: build/${{ env.QT_VERSION }}
+        key: aqt-install-${{ matrix.variant.runner }}-${{ matrix.variant.arch }}-${{ env.QT_VERSION }}-${{ matrix.variant.qt-compiler }}
+
+    - name: Setup Qt (Windows)
+      if: steps.cache-artifacts.outputs.cache-hit != 'true' && startsWith(matrix.variant.runner, 'windows-')
+      run: |
+        python -m pip install aqtinstall --user --upgrade
+        python -m aqt install-qt -O build windows desktop ${{ env.QT_VERSION }} ${{ matrix.variant.qt-compiler }}
+
+    - name: Setup Qt (Linux)
+      if: steps.cache-artifacts.outputs.cache-hit != 'true' && startsWith(matrix.variant.runner, 'ubuntu-')
+      run: |
+        python -m pip install aqtinstall --user --upgrade
+        python -m aqt install-qt -O build linux desktop ${{ env.QT_VERSION }} ${{ matrix.variant.qt-compiler }}
+
+    - name: Setup Qt (MacOS)
+      if: steps.cache-artifacts.outputs.cache-hit != 'true' && startsWith(matrix.variant.runner, 'macos-')
+      run: |
         python -m pip install aqtinstall --user --upgrade
         python -m aqt install-qt -O build mac desktop ${{ env.QT_VERSION }} ${{ matrix.variant.qt-compiler }}
 


### PR DESCRIPTION
Qt install using `aqt` is a fairly long process that can sometimes fail (network error, corrupted download, etc.)
With this PR, we cache per platform and per version so that the first successful download can be reused with the next builds.