### PR TITLE
Automatically trigger the build + publish workflow on new tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,13 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 env:
   VERSION: 0.1.0


### PR DESCRIPTION
Creating a new tag will now trigger the build workflow, followed by the publish to PyPI action making the whole publishing process entirely automated.