### PR TITLE
[CI] Fixed wheel path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,9 +156,9 @@ jobs:
         id: download_wheels
         with:
           name: die-python-py${{ matrix.variant.py-version }}-${{ matrix.variant.runner }}.${{ matrix.variant.config }}
-          path: wheel
+          path: .
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: ${{ steps.download_wheels.outputs.download-path }}/wheel/
+          packages-dir: ${{ steps.download_wheels.outputs.download-path }}
           print-hash: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,9 @@ jobs:
       with:
         name: die-python-py${{ matrix.variant.py-version }}-${{ matrix.variant.runner }}.${{ matrix.variant.config }}
         path: |
-          wheel/
+          wheel/*.whl
+        if-no-files-found: error
+        retention-days: 1
 
   publish:
     needs: bindings


### PR DESCRIPTION
It seems GH won't rebuild wheel tree structure when packaging artifacts.
This PR changes the location of the wheels to be uploaded to PyPI to the root folder so the GHA can find them