### PR TITLE
[CI] Use `cibuildwheel` instead of wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,21 +107,20 @@ jobs:
         python -m pytest -v python/tests
 
     - name: Build wheels (Linux)
-      if: startsWith(matrix.variant.runner, 'ubuntu-')
+      if: startsWith(matrix.variant.runner, 'ubuntu-') == true && matrix.variant.py-version == '3.8'
       uses: pypa/cibuildwheel@v2.19.1
 
     - name: Build wheels (Others)
       if: startsWith(matrix.variant.runner, 'ubuntu-') == false
       run: |
-        mkdir wheel
-        python -m pip wheel . --wheel-dir wheel --progress-bar on
+        mkdir wheelhouse
+        python -m pip wheel . --wheel-dir wheelhouse --progress-bar on
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: die-python-py${{ matrix.variant.py-version }}-${{ matrix.variant.runner }}.${{ matrix.variant.config }}
         path: |
-          wheel/die_python-*.whl
           wheelhouse/die_python-*.whl
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,12 +117,12 @@ jobs:
         python -m pip wheel . --wheel-dir wheelhouse --progress-bar on
 
     - name: Upload artifacts
+      if: startsWith(matrix.variant.runner, 'ubuntu-') == false || matrix.variant.py-version != '3.8'
       uses: actions/upload-artifact@v4
       with:
         name: die-python-py${{ matrix.variant.py-version }}-${{ matrix.variant.runner }}.${{ matrix.variant.config }}
         path: |
           wheelhouse/die_python-*.whl
-        if-no-files-found: error
         retention-days: 1
 
   publish:
@@ -138,10 +138,10 @@ jobs:
           - {runner: macos-13,      config: Release,         py-version: '3.11' }
           - {runner: macos-13,      config: Release,         py-version: '3.12' }
           - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.8' }
-          - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.9' }
-          - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.10' }
-          - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.11' }
-          - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.12' }
+          # - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.9' }
+          # - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.10' }
+          # - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.11' }
+          # - {runner: ubuntu-22.04,  config: RelWithDebInfo,  py-version: '3.12' }
           - {runner: windows-2019,  config: RelWithDebInfo,  py-version: '3.8' }
           - {runner: windows-2019,  config: RelWithDebInfo,  py-version: '3.9' }
           - {runner: windows-2019,  config: RelWithDebInfo,  py-version: '3.10' }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,10 +106,8 @@ jobs:
       run: |
         python -m pytest -v python/tests
 
-    - name: Build WHL
-      run: |
-        mkdir wheel
-        python -m pip wheel . --wheel-dir ./wheel --progress-bar on
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.19.1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -117,6 +115,7 @@ jobs:
         name: die-python-py${{ matrix.variant.py-version }}-${{ matrix.variant.runner }}.${{ matrix.variant.config }}
         path: |
           wheel/die_python-*.whl
+          wheelhouse/die_python-*.whl
         if-no-files-found: error
         retention-days: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,15 @@ jobs:
       run: |
         python -m pytest -v python/tests
 
-    - name: Build wheels
+    - name: Build wheels (Linux)
+      if: startsWith(matrix.variant.runner, 'ubuntu-')
       uses: pypa/cibuildwheel@v2.19.1
+
+    - name: Build wheels (Others)
+      if: startsWith(matrix.variant.runner, 'ubuntu-') == false
+      run: |
+        mkdir wheel
+        python -m pip wheel . --wheel-dir wheel --progress-bar on
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 .pytest_cache
 *.pyc
 aqtinstall.log
+wheel
+wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,11 @@ cmake.minimum-version = "3.20"
 # cmake.verbose = true
 # logging.level = "DEBUG"
 # cmake.build-type = "Debug"
+
+[tool.cibuildwheel]
+build = "*"
+skip = "cp27-* cp35-* cp36-* cp37-* pp*"
+test-skip = ""
+free-threaded-support = false
+archs = ["x86_64"]
+manylinux-x86_64-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ cmake.minimum-version = "3.20"
 # cmake.build-type = "Debug"
 
 [tool.cibuildwheel]
-build = "*"
-skip = "cp27-* cp35-* cp36-* cp37-* pp*"
+build = ""
+skip = "cp27-* cp35-* cp36-* cp37-* pp* *musllinux*"
 test-skip = ""
 free-threaded-support = false
 # use images from https://github.com/pypa/manylinux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,7 @@ build = "*"
 skip = "cp27-* cp35-* cp36-* cp37-* pp*"
 test-skip = ""
 free-threaded-support = false
+# use images from https://github.com/pypa/manylinux
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"


### PR DESCRIPTION
For Linux wheels cannot be uploaded directly to PyPI (see [PEP 513](https://peps.python.org/pep-0513/#rationale)) and must be appropriately converted first.
This PR uses the GH Actions `cibuildwheel` to help in that process.