### PR TITLE
[CI] Fix wheel location before publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,4 +184,5 @@ jobs:
 
       - name: Publish package
         run: |
-          uv publish
+          mv */**/*.whl .
+          uv publish *.whl


### PR DESCRIPTION
# Description

This PR fixes wheels location when publishing using `uv`, otherwise, would return wheel not found when the github action executes